### PR TITLE
 Fix broken tar relative symlink + delete unnecessary 'require'

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -223,9 +223,7 @@ class Gem::Package
       stat = File.lstat file
 
       if stat.symlink?
-        relative_dir = File.dirname(file).sub("#{Dir.pwd}/", '')
-        target_path = File.join(relative_dir, File.readlink(file))
-        tar.add_symlink file, target_path, stat.mode
+        tar.add_symlink file, File.readlink(file), stat.mode
       end
 
       next unless stat.file?

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -189,7 +189,7 @@ class TestGemPackage < Gem::Package::TarTestCase
     end
 
     assert_equal %w[lib/code.rb], files
-    assert_equal [{'lib/code_sym.rb' => 'lib/code.rb'}], symlinks
+    assert_equal [{'lib/code_sym.rb' => 'code.rb'}], symlinks
   end
 
   def test_build

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require 'rubygems/package/tar_test_case'
-require 'rubygems/simple_gem'
 
 class TestGemPackage < Gem::Package::TarTestCase
 


### PR DESCRIPTION
# Description:
Fix for #2007

Mainly revert #1578

2nd commit:
`rubygems/simple_gem.rb` has already been removed
Shows here https://github.com/rubygems/rubygems/blob/master/Manifest.txt#L499

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
